### PR TITLE
Fixed score submission not disabling.

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -45,14 +45,14 @@ namespace bs_utils {
             getLogger().info("Mod: %s is disabling score submission multiple times!", info.id.c_str());
             return;
         }
-        if (!disablingMods.empty() && enabled) {
+        disablingMods.insert(info);
+        if (enabled) {
             // Disable score submission
             getLogger().info("Mod: %s is disabling score submission!", info.id.c_str());
             setenv("disable_ss_upload", "1", true);
             // this will also disable vanilla score submission via main.cpp
             enabled = false;
         }
-        disablingMods.insert(info);
     }
     const std::unordered_set<DisablingModInfo, DisablingModInfoHash> Submission::getDisablingMods() {
         return disablingMods;


### PR DESCRIPTION
Moved the insert to before the second if block, and removed the empty check to make sure score submission works properly.
I've done some testing and this works adequately, although I should probably test with multiple mods just to be sure.